### PR TITLE
Remove vagrant-vbguest plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You also need to install the following Vagrant plugin:
 ```bash
 vagrant plugin install vagrant-disksize
 vagrant plugin install vagrant-reload
-vagrant plugin install vagrant-vbguest
 vagrant plugin install vagrant-scp
 ```
 


### PR DESCRIPTION
As explained in issue #2, a vbguest plugin mismatch is causing `vagrant up` to halt. This commit removes vbguest, at 
least temporarily, to solve the issue

Closes #2 